### PR TITLE
added params to be able to set the concourse to different server and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Create or delete a webhook using the configured parameters.
     webhook_token: your-token
     operation: create
     events: [push, pull_request]
+    url: your-url-for-webhook
+    secret: webhook-secret
     pipeline: pipeline-name
     pipeline_instance_vars: {
         your_instance_var_name: value
@@ -66,6 +68,8 @@ Create or delete a webhook using the configured parameters.
 -   `events`: *Optional*. An array of [events](https://developer.github.com/webhooks/#events) which will trigger your webhook. Default: `push`
 -	`pipeline`: *Optional.* Defaults to the name of the pipeline executing the task
 -	`pipeline_instance_vars`: *Optional.* Instance vars to append to the webhook url. These help Concourse identify which [instance pipeline](https://concourse-ci.org/resources.html#schema.resource.webhook_token) it should invoke
+-	`url`: *Optional.* Defaults to the ATC_EXTERNAL_URL set on concourse environment
+-	`secret`: *Optional.* secret for webhooks
 
 ## Example
 Include the github-webhook-resource in your pipeline.yml file

--- a/bin/out.js
+++ b/bin/out.js
@@ -47,7 +47,13 @@ stdin.on('end', function () {
 
 function buildUrl(source, params) {
     const instanceVars = buildInstanceVariables(params);
-    return encodeURI(`${env.ATC_EXTERNAL_URL}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${params.pipeline ? params.pipeline : env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
+    const webhookUrl = params.url
+    if (webhookUrl){
+        return encodeURI(`${webhookUrl}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${params.pipeline ? params.pipeline : env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
+    }else
+    {
+        return encodeURI(`${env.ATC_EXTERNAL_URL}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${params.pipeline ? params.pipeline : env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
+    }
 }
 
 function buildInstanceVariables(params) {
@@ -84,7 +90,8 @@ async function processWebhook(source, params) {
 
     const config = {
         'url': url,
-        'content-type': 'json'
+        'content-type': 'json',
+        'secret' : params.secret
     };
 
     const body = {

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -34,6 +34,8 @@ const configSchema = {
                 repo:          { type: 'string' },
                 resource_name: { type: 'string' },
                 webhook_token: { type: 'string' },
+                secret: {type : 'string'},
+                url: {type: 'string'},
                 events:        {
                     type: 'array',
                     items: {

--- a/bin/validate.test.js
+++ b/bin/validate.test.js
@@ -70,6 +70,8 @@ describe('validate.input', () => {
                 repo: '',
                 resource_name: '',
                 webhook_token: '',
+                secret: '',
+                url: '',
                 operation: 'create'
             }
         };
@@ -118,6 +120,8 @@ describe('validate.input', () => {
             'params.webhook_token',
             'params.operation',
             'params.pipeline',
+            'params.secret',
+            'params.url',
         ];
 
         constrainedFields.forEach(field => {


### PR DESCRIPTION
- added params to be able to set the concourse to different server and secret

<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [ ] Other (please explain):

<!-- If your change addresses an issue, please paste the issue number below. -->
**Addresses #**


**What changes did you make? (Give a brief overview)**


**Is there anything specific you would like reviewers to focus on?**
